### PR TITLE
Color skill requirements in tooltip by player level

### DIFF
--- a/src/main/java/com/demonicpacts/DemonicPactsTooltipOverlay.java
+++ b/src/main/java/com/demonicpacts/DemonicPactsTooltipOverlay.java
@@ -4,6 +4,7 @@ import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.NPC;
+import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
@@ -15,9 +16,14 @@ import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 import javax.inject.Inject;
 import java.awt.*;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class DemonicPactsTooltipOverlay extends Overlay
 {
+    private static final Pattern SKILL_REQ_PATTERN = Pattern.compile(
+        "\\b(Attack|Defence|Strength|Hitpoints|Ranged|Prayer|Magic|Runecraft|Construction|Agility|Herblore|Thieving|Crafting|Fletching|Slayer|Hunter|Mining|Smithing|Fishing|Cooking|Firemaking|Woodcutting|Farming)\\s+(\\d+)\\+?");
+
     private final Client client;
     private final DemonicPactsConfig config;
     private final TooltipManager tooltipManager;
@@ -443,8 +449,8 @@ public class DemonicPactsTooltipOverlay extends Overlay
 
             if (config.showRequirements() && task.getRequirements() != null && !task.getRequirements().isEmpty())
             {
-                sb.append("<br><col=ffffff>Requires: </col><col=ff6666>")
-                    .append(task.getRequirements()).append("</col>");
+                sb.append("<br><col=ffffff>Requires: </col>")
+                    .append(formatRequirements(task.getRequirements()));
             }
 
             if (task.getQuantity() > 1)
@@ -460,5 +466,28 @@ public class DemonicPactsTooltipOverlay extends Overlay
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Wrap each skill-level token (e.g. "Defence 60", "Hunter 29+") in a green
+     * or red color tag based on the player's real level vs the required level.
+     * Non-skill text (quest names, connectors) is left uncolored.
+     */
+    private String formatRequirements(String requirements)
+    {
+        Matcher m = SKILL_REQ_PATTERN.matcher(requirements);
+        StringBuilder out = new StringBuilder();
+        int last = 0;
+        while (m.find())
+        {
+            out.append(requirements, last, m.start());
+            int reqLevel = Integer.parseInt(m.group(2));
+            int playerLevel = client.getRealSkillLevel(Skill.valueOf(m.group(1).toUpperCase()));
+            String color = playerLevel >= reqLevel ? "00ff00" : "ff6666";
+            out.append("<col=").append(color).append(">").append(m.group()).append("</col>");
+            last = m.end();
+        }
+        out.append(requirements.substring(last));
+        return out.toString();
     }
 }


### PR DESCRIPTION
## Summary

Color skill-level tokens in the tooltip `Requires:` line by the player's actual level instead of always showing the whole line in red.

- Green if the player meets the requirement (e.g. `Defence 60` when you have 70 Defence)
- Red if not (e.g. `Hunter 29+` when you have 20 Hunter)
- Non-skill text (quest names, connectors) left uncolored

## Notes


Detection is a regex over the 23 OSRS skill names followed by a level (optionally with `+`). Unknown tokens fall through unchanged, so non-matching requirement text is unaffected.

Closes #14 

## Examples

| Before | After |
| --- | --- |
| <img width="509" height="257" alt="pre example 1" src="https://github.com/user-attachments/assets/aa8e6d6a-b371-4560-bd7a-e1d74ab08a6c" /> | <img width="534" height="261" alt="post example 1" src="https://github.com/user-attachments/assets/f0a9ca58-e04e-4112-ad4b-06a832066c2e" /> |
| <img width="379" height="235" alt="pre example 2" src="https://github.com/user-attachments/assets/f070d55e-6221-452c-be86-abe5c0e56356" /> | <img width="381" height="245" alt="post example 2" src="https://github.com/user-attachments/assets/02554f06-1f9f-40da-aad3-b31c613a3392" /> |